### PR TITLE
NW.js v0.14.0 Released

### DIFF
--- a/files/settings.cfg
+++ b/files/settings.cfg
@@ -305,4 +305,4 @@ linux_64_dir_prefix = 'node-webkit-v{}-linux-x64'
                                  'force_download']"""
 
 [version_info]
-    urls="""['https://raw.githubusercontent.com/nwjs/nw.js/nw13/CHANGELOG.md']"""
+    urls="""['https://raw.githubusercontent.com/nwjs/nw.js/nw14/CHANGELOG.md']"""


### PR DESCRIPTION
Move changelog URL to `nw14` to get latest release.
Since there is no difference in packaging between 0.13 and 0.14, (and tested in Windows 10 pro and OSX 10.11.4), I think it's OK to change the `version_info` URL.:ok_hand:  