### PR TITLE
Implement blacklisting and whitelisting

### DIFF
--- a/command_line.py
+++ b/command_line.py
@@ -89,7 +89,7 @@ class CommandBase(object):
                 for line in f:
                     nw_version.values.append(line.strip())
         except IOError:
-            nw_version.values.append(nw_version.default_value)
+            pass
 
     def get_nw_versions(self):
         """Get the already downloaded nw versions from the settings"""

--- a/files/settings.cfg
+++ b/files/settings.cfg
@@ -128,6 +128,16 @@ linux_64_dir_prefix = 'nwjs-v{}-linux-x64'
             default_value=''
             type='string'
             description='Type "%(" to see a list of options to reference. Name your output folder.\n Include slashes to make sub-directories.'
+        [[[blacklist]]]
+            display_name='Blacklist'
+            default_value=''
+            type='string'
+            description='Glob-style blacklist files/directories. Each line is a new pattern. Ex: *.jpeg, .git, *file[s].txt'
+        [[[whitelist]]]
+            display_name='Whitelist'
+            default_value=''
+            type='string'
+            description='Glob-style whitelist files/directories. Each line is a new pattern. Ex: *.jpeg, .git, *file[s].txt.\nWhitelist trumps blacklist.'
 
     [[window_settings]]
         [[[id]]]
@@ -238,6 +248,7 @@ linux_64_dir_prefix = 'nwjs-v{}-linux-x64'
     [[download_settings]]
         [[[nw_version]]]
             display_name='NW.js version'
+            required=True
             default_value=None
             values=[]
             type='list'

--- a/main.py
+++ b/main.py
@@ -210,18 +210,6 @@ class MainWindow(QtGui.QMainWindow, CommandBase):
         if action:
             self.load_project(action.data())
 
-    def setup_nw_versions(self):
-        """Loads stored versions that were previously retrieved."""
-        nw_version = self.get_setting('nw_version')
-        try:
-            f = codecs.open(utils.get_data_file_path(config.VER_FILE),
-                            encoding='utf-8')
-            for line in f:
-                nw_version.values.append(line.strip())
-            f.close()
-        except IOError:
-            nw_version.values.append(nw_version.default_value)
-
     def create_application_layout(self):
         """Create all widgets and set the central widget."""
         self.main_layout = QtGui.QVBoxLayout()

--- a/main.py
+++ b/main.py
@@ -37,6 +37,7 @@ from config import __version__ as __gui_version__
 from util_classes import ExistingProjectDialog
 from util_classes import BackgroundThread, Validator
 from util_classes import CompleterLineEdit, TagsCompleter
+from util_classes import TreeBrowser
 
 from PySide import QtGui, QtCore
 from PySide.QtGui import (QApplication, QHBoxLayout, QVBoxLayout)
@@ -989,6 +990,9 @@ class MainWindow(QtGui.QMainWindow, CommandBase):
 
         self.set_window_icon()
         self.open_export_button.setEnabled(True)
+
+        self.tree_browser.init(directory, ['.*'])
+
         self.update_json = True
 
     def init_main_field(self, directory):
@@ -1159,7 +1163,7 @@ class MainWindow(QtGui.QMainWindow, CommandBase):
 
         ex_setting_order = self.settings['order']['export_setting_order']
 
-        vlayout = self.create_layout(ex_setting_order, cols=4)
+        vlayout = self.create_layout(ex_setting_order, cols=1)
 
         output_name_layout = self.create_output_name_pattern_line()
 
@@ -1167,14 +1171,39 @@ class MainWindow(QtGui.QMainWindow, CommandBase):
 
         script_layout = self.create_script_layout()
 
+        hlayout = QtGui.QHBoxLayout()
+
+        platform_group = QtGui.QGroupBox('Platforms')
+        playout = QtGui.QVBoxLayout()
+        playout.addLayout(vlayout)
+        platform_group.setLayout(playout)
+
+        hlayout.addWidget(platform_group)
+
+        tree_layout = self.create_blacklist_layout()
+
+        tree_group = QtGui.QGroupBox('Files')
+        tree_group.setLayout(tree_layout)
+
+        hlayout.addWidget(tree_group)
+
         vbox = QtGui.QVBoxLayout()
-        vbox.addLayout(vlayout)
+        vbox.addLayout(hlayout)
         vbox.addLayout(output_name_layout)
         vbox.addLayout(output_layout)
         vbox.addLayout(script_layout)
 
         group_box.setLayout(vbox)
         return group_box
+
+    def create_blacklist_layout(self):
+        blacklist_layout = QtGui.QVBoxLayout()
+
+        self.tree_browser = TreeBrowser()
+
+        blacklist_layout.addWidget(self.tree_browser)
+
+        return blacklist_layout
 
     def create_output_name_pattern_line(self):
         output_name_layout = QtGui.QHBoxLayout()

--- a/main.py
+++ b/main.py
@@ -979,7 +979,13 @@ class MainWindow(QtGui.QMainWindow, CommandBase):
         self.set_window_icon()
         self.open_export_button.setEnabled(True)
 
-        self.tree_browser.init(directory, ['.*'])
+        blacklist_setting = self.get_setting('blacklist')
+
+        output_blacklist = os.path.basename(self.output_dir())
+
+        self.tree_browser.init(directory,
+                               blacklist=(blacklist_setting.value.split('\n') +
+                                          ['*'+output_blacklist+'*']))
 
         self.update_json = True
 
@@ -1152,6 +1158,7 @@ class MainWindow(QtGui.QMainWindow, CommandBase):
         ex_setting_order = self.settings['order']['export_setting_order']
 
         vlayout = self.create_layout(ex_setting_order, cols=1)
+        vlayout.setContentsMargins(0, 10, 0, 0)
 
         output_name_layout = self.create_output_name_pattern_line()
 
@@ -1162,18 +1169,15 @@ class MainWindow(QtGui.QMainWindow, CommandBase):
         hlayout = QtGui.QHBoxLayout()
 
         platform_group = QtGui.QGroupBox('Platforms')
+        platform_group.setContentsMargins(0, 10, 0, 0)
         playout = QtGui.QVBoxLayout()
         playout.addLayout(vlayout)
         platform_group.setLayout(playout)
 
         hlayout.addWidget(platform_group)
 
-        tree_layout = self.create_blacklist_layout()
-
-        tree_group = QtGui.QGroupBox('Files')
-        tree_group.setLayout(tree_layout)
-
-        hlayout.addWidget(tree_group)
+        tree_layout = self.create_blacklist_layout(hlayout)
+        tree_layout.setContentsMargins(0, 10, 0, 0)
 
         vbox = QtGui.QVBoxLayout()
         vbox.addLayout(hlayout)
@@ -1184,14 +1188,84 @@ class MainWindow(QtGui.QMainWindow, CommandBase):
         group_box.setLayout(vbox)
         return group_box
 
-    def create_blacklist_layout(self):
-        blacklist_layout = QtGui.QVBoxLayout()
+    def create_blacklist_layout(self, blacklist_layout):
 
         self.tree_browser = TreeBrowser()
+        self.tree_browser.setContentsMargins(0, 0, 0, 0)
 
+        self.blacklist_text = QtGui.QPlainTextEdit()
+        self.whitelist_text = QtGui.QPlainTextEdit()
+
+        hlayout = QtGui.QHBoxLayout()
+
+        blacklayout = QtGui.QVBoxLayout()
+        whitelayout = QtGui.QHBoxLayout()
+
+        blacklayout.addWidget(self.blacklist_text)
+        whitelayout.addWidget(self.whitelist_text)
+
+        whitelist_setting = self.get_setting('whitelist')
+        blacklist_setting = self.get_setting('blacklist')
+
+        self.blacklist_text.setStatusTip(blacklist_setting.description)
+        self.whitelist_text.setStatusTip(whitelist_setting.description)
+
+        self.blacklist_text.setObjectName(blacklist_setting.name)
+        self.whitelist_text.setObjectName(whitelist_setting.name)
+
+        blackgroup = QtGui.QGroupBox(blacklist_setting.display_name)
+        whitegroup = QtGui.QGroupBox(whitelist_setting.display_name)
+
+        blackgroup.setLayout(blacklayout)
+        whitegroup.setLayout(whitelayout)
+
+        blacklist_layout.addWidget(blackgroup)
+        blacklist_layout.addWidget(whitegroup)
         blacklist_layout.addWidget(self.tree_browser)
 
+        self.blacklist_text.textChanged.connect(
+            self.call_with_object('setting_changed',
+                                  self.blacklist_text,
+                                  blacklist_setting)
+        )
+
+        self.whitelist_text.textChanged.connect(
+            self.call_with_object('setting_changed',
+                                  self.whitelist_text,
+                                  whitelist_setting)
+        )
+
+        self.blacklist_text.textChanged.connect(
+            self.call_with_object('blacklist_changed',
+                                  self.blacklist_text,
+                                  blacklist_setting)
+        )
+
+        self.whitelist_text.textChanged.connect(
+            self.call_with_object('whitelist_changed',
+                                  self.whitelist_text,
+                                  whitelist_setting)
+        )
+
         return blacklist_layout
+
+    def blacklist_changed(self, text, blacklist_setting):
+        new_val = text.toPlainText()
+        output_blacklist = os.path.basename(self.output_dir())
+        self.tree_browser.refresh(blacklist=(new_val.split('\n') +
+                                            ['*'+output_blacklist+'*']))
+
+    def whitelist_changed(self, text, whitelist_setting):
+        new_val = text.toPlainText()
+        self.tree_browser.refresh(whitelist=new_val.split('\n'))
+
+    @property
+    def used_project_files(self):
+        return self.tree_browser.files
+
+    @property
+    def used_project_dirs(self):
+        return self.tree_browser.dirs
 
     def create_output_name_pattern_line(self):
         output_name_layout = QtGui.QHBoxLayout()
@@ -1432,7 +1506,10 @@ class MainWindow(QtGui.QMainWindow, CommandBase):
                         old_val = setting.default_value
 
                     setting.value = old_val.replace('\\', '\\\\')
-                    widget.setText(old_val)
+                    if hasattr(widget, 'setText'):
+                        widget.setText(old_val)
+                    elif hasattr(widget, 'setPlainText'):
+                        widget.setPlainText(old_val)
                 elif setting.type == 'strings':
                     old_val = []
                     if setting.default_value is not None:
@@ -1494,7 +1571,11 @@ class MainWindow(QtGui.QMainWindow, CommandBase):
                 setting.type == 'file' or
                 setting.type == 'folder' or
                 setting.type == 'int'):
-            setting.value = args[0]
+            if args:
+                setting.value = args[0]
+            else:
+                setting.value = obj.toPlainText()
+
             if not setting.value:
                 setting.value = setting.default_value
         elif setting.type == 'strings':
@@ -1646,7 +1727,10 @@ class MainWindow(QtGui.QMainWindow, CommandBase):
                         setting.type == 'folder' or
                         setting.type == 'int'):
                     val_str = self.convert_val_to_str(setting.value)
-                    setting_field.setText(setting.filter_name(val_str))
+                    if hasattr(setting_field, 'setText'):
+                        setting_field.setText(setting.filter_name(val_str))
+                    elif hasattr(setting_field, 'setPlainText'):
+                        setting_field.setPlainText(setting.filter_name(val_str))
                 if setting.type == 'strings':
                     vals = [self.convert_val_to_str(v) for v in setting.value]
                     setting_field.setText(','.join(vals))

--- a/utils.py
+++ b/utils.py
@@ -15,6 +15,7 @@ import shutil
 import subprocess
 from appdirs import AppDirs
 import validators
+import traceback
 
 from PySide import QtCore
 
@@ -206,7 +207,7 @@ def open_folder_in_explorer(path):
     else:
         subprocess.Popen(["xdg-open", path])
 
-def zip_files(zip_file_name, *args, **kwargs):
+def zip_files(zip_file_name, project_dir, *args, **kwargs):
     """
     Zip files into an archive programmatically.
 
@@ -222,14 +223,13 @@ def zip_files(zip_file_name, *args, **kwargs):
     exclude_paths = kwargs.pop('exclude_paths', [])
     old_path = os.getcwd()
 
+    os.chdir(project_dir)
+
     for arg in args:
         if is_windows():
             arg = '\\\\?\\'+os.path.abspath(arg).replace('/', '\\')
         if os.path.exists(arg):
             if os.path.isdir(arg):
-                directory = os.path.abspath(arg)
-                os.chdir(directory)
-
                 for root, dirs, files in os.walk(directory):
                     excluded = False
                     for exclude_path in exclude_paths:
@@ -260,10 +260,7 @@ def zip_files(zip_file_name, *args, **kwargs):
                                 pass
 
             else:
-                file = os.path.abspath(arg)
-                directory = os.path.abspath(path_join(file, '..'))
-                os.chdir(directory)
-                file_loc = os.path.relpath(arg, directory)
+                file_loc = arg
                 if verbose:
                     log(file_loc)
                 try:


### PR DESCRIPTION
Blacklisting and whitelisting can now be done on the export page. Blacklists are applied first, and then whitelists. This means you can blacklist a directory but whitelist a file within that directory. In the GUI, patterns are separated by lines. In command line mode, patterns are separated using commas (`,`).

To blacklist/whitelist a directory or file called "project_files" recursively, put this into the new blacklist/whitelist field:

```
*project_files*
```

You can also exclude a directory in the root of your project directory like so:

```
project_files*
```

There is also support for simple patterns. To match `files` and `filed`, you can do:

```
file[sd]
```

In the GUI, a file tree on the right of the new fields shows which files will be included in the build. This will show *all* files including hidden ones if they are allowed with the blacklist/whitelist patterns.